### PR TITLE
Add alpha color to all layers except the background

### DIFF
--- a/src/Viewer/Interactors/tools.js
+++ b/src/Viewer/Interactors/tools.js
@@ -63,16 +63,15 @@ export default function MiscInteractors () {
         <SketchPicker
           onChange={
             (color) => {
-              const alpha = color.rgb.a
+              if (color.hex === 'transparent') return
               setColors({
                 ...colors,
-                mesh: color.hex,
-                meshOpacity: alpha
+                mesh: { rgb: color.hex, a: color.rgb.a }
               })
             }
           }
-          color={colors.mesh +
-          Math.round((colors.meshOpacity * 0xff)).toString(16)}
+          color={colors.mesh.rgb +
+          Math.round((colors.mesh.a * 0xff)).toString(16)}
 
         />
         <ResetButton
@@ -96,17 +95,18 @@ export default function MiscInteractors () {
         icon={<PaintIcon isActivated={layerTools.activeTool ===
         tools.colorPickers.pointCloud} />}
       >
-        <SketchPicker disableAlpha
+        <SketchPicker
           onChange={
             (color) => {
-              console.log(color)
+              if (color.hex === 'transparent') return
               setColors({
                 ...colors,
-                pointCloud: color.rgb
+                pointCloud: { rgb: color.hex, a: color.rgb.a }
               })
             }
           }
-          color={colors.pointCloud}
+          color={colors.pointCloud.rgb +
+            Math.round(colors.pointCloud.a * 0xff).toString(16)}
         />
         <ResetButton
           onClick={
@@ -129,16 +129,18 @@ export default function MiscInteractors () {
         icon={<PaintIcon isActivated={layerTools.activeTool ===
           tools.colorPickers.skeleton} />}
       >
-        <SketchPicker disableAlpha
+        <SketchPicker
           onChange={
             (color) => {
+              if (color.hex === 'transparent') return
               setColors({
                 ...colors,
-                skeleton: color.hex
+                skeleton: { rgb: color.hex, a: color.rgb.a }
               })
             }
           }
-          color={colors.skeleton}
+          color={colors.skeleton.rgb +
+            Math.round(colors.skeleton.a * 0xff).toString(16)}
         />
         <ResetButton
           onClick={
@@ -164,9 +166,10 @@ export default function MiscInteractors () {
         icon={<PaintIcon isActivated={layerTools.activeTool ===
           tools.colorPickers.organs} />}
       >
-        <SketchPicker disableAlpha
+        <SketchPicker
           onChange={
             (color) => {
+              if (color.hex === 'transparent') return
               let color2 = color.hsl
               // Use a lighter color for the second organ of the pair
               color2.l += 0.3
@@ -179,8 +182,8 @@ export default function MiscInteractors () {
                 // We slice the array because it has to be an immutable change
                 let copy = colors.organs.slice()
                 const next = selectedAngle + 1
-                copy[selectedAngle] = color.hex
-                copy[next] = color2String
+                copy[selectedAngle] = { rgb: color.hex, a: color.rgb.a }
+                copy[next] = { rgb: color2String, a: color.rgb.a }
                 setColors({
                   ...colors,
                   organs: copy
@@ -188,14 +191,20 @@ export default function MiscInteractors () {
               } else {
                 setColors({
                   ...colors,
-                  globalOrganColors: [color.hex, color2String]
+                  globalOrganColors: [
+                    { rgb: color.hex, a: color.rgb.a },
+                    { rgb: color2String, a: color.rgb.a }
+                  ]
                 })
               }
             }
           }
-          color={(selectedAngle !== undefined && selectedAngle !== null)
-            ? colors.organs[selectedAngle]
-            : colors.globalOrganColors[0]}
+          color={(selectedAngle !== undefined && selectedAngle !== null &&
+            colors.organs[selectedAngle])
+            ? colors.organs[selectedAngle].rgb +
+              Math.round(colors.organs[selectedAngle].a * 0xff).toString(16)
+            : colors.globalOrganColors[0].rgb +
+              Math.round(colors.globalOrganColors[0].a * 0xff).toString(16)}
         />
         <ResetButton
           onClick={

--- a/src/Viewer/Panels/Graph/graph.js
+++ b/src/Viewer/Panels/Graph/graph.js
@@ -443,17 +443,17 @@ const Chart = sceneWrapper(({ valueTransformFn, ifManualData, data, unit, contai
               selected={selectedAngle === i}
               hoveredColor={
                 colors.organs[hoveredAngle]
-                  ? colors.organs[hoveredAngle]
+                  ? colors.organs[hoveredAngle].rgb
                   : hoveredAngle % 2
-                    ? colors.globalOrganColors[1]
-                    : colors.globalOrganColors[0]
+                    ? colors.globalOrganColors[1].rgb
+                    : colors.globalOrganColors[0].rgb
               }
               selectedColor={
                 colors.organs[selectedAngle]
-                  ? colors.organs[selectedAngle]
+                  ? colors.organs[selectedAngle].rgb
                   : selectedAngle % 2
-                    ? colors.globalOrganColors[1]
-                    : colors.globalOrganColors[0]
+                    ? colors.globalOrganColors[1].rgb
+                    : colors.globalOrganColors[0].rgb
               }
               hovered={hoveredAngle === i}
               onMouseEnter={() => setHoveredAngle(i)}
@@ -481,13 +481,14 @@ const Chart = sceneWrapper(({ valueTransformFn, ifManualData, data, unit, contai
               (isNotNullAndUndefiend(selectedAngle) &&
               !isNotNullAndUndefiend(hoveredAngle))
                 ? colors.organs[selectedAngle + 1]
-                  ? Color(colors.organs[selectedAngle + 1]).toString()
-                  : Color(colors.globalOrganColors[selectedAngle % 2 ? 0 : 1])
+                  ? Color(colors.organs[selectedAngle + 1].rgb).toString()
+                  : Color(colors.globalOrganColors[selectedAngle % 2 ? 0 : 1].rgb)
                     .toString()
                 : isNotNullAndUndefiend(hoveredAngle)
                   ? colors.organs[hoveredAngle + 1]
-                    ? Color(colors.organs[hoveredAngle + 1]).toString()
-                    : Color(colors.globalOrganColors[hoveredAngle % 2 ? 0 : 1])
+                    ? Color(colors.organs[hoveredAngle + 1].rgb).toString()
+                    : Color(colors.globalOrganColors[hoveredAngle % 2 ? 0 : 1]
+                      .rgb)
                       .toString()
                   : darkGreen
             }
@@ -522,13 +523,15 @@ const Chart = sceneWrapper(({ valueTransformFn, ifManualData, data, unit, contai
               (isNotNullAndUndefiend(selectedAngle) &&
               !isNotNullAndUndefiend(hoveredAngle))
                 ? colors.organs[selectedAngle]
-                  ? Color(colors.organs[selectedAngle]).toString()
-                  : Color(colors.globalOrganColors[selectedAngle % 2 ? 1 : 0])
+                  ? Color(colors.organs[selectedAngle].rgb).toString()
+                  : Color(colors.globalOrganColors[selectedAngle % 2 ? 1 : 0]
+                    .rgb)
                     .toString()
                 : isNotNullAndUndefiend(hoveredAngle)
                   ? colors.organs[hoveredAngle]
-                    ? Color(colors.organs[hoveredAngle]).toString()
-                    : Color(colors.globalOrganColors[hoveredAngle % 2 ? 1 : 0])
+                    ? Color(colors.organs[hoveredAngle].rgb).toString()
+                    : Color(colors.globalOrganColors[hoveredAngle % 2 ? 1 : 0]
+                      .rgb)
                       .toString()
                   : Color('#78D89D').toString()
             }

--- a/src/Viewer/World/entities/angles.js
+++ b/src/Viewer/World/entities/angles.js
@@ -47,20 +47,21 @@ EnhancedTHREE = setLine2(EnhancedTHREE)
 export default class Angles {
   constructor (angles, parent) {
     this.group = new THREE.Object3D()
-    this.globalColors = ['#3a4d45', '#00a960']
+    this.globalColors = [{ rgb: '#3a4d45', a: 0.2 }, { rgb: '#00a960', a: 0.2 }]
 
     angles.forEach((points, index) => {
       const geometry = new EnhancedTHREE.LineGeometry()
       geometry.setPositions(flatten(points))
 
       const color = new THREE.Color(index % 2 === 0
-        ? this.globalColors[0]
-        : this.globalColors[1])
+        ? this.globalColors[0].rgb
+        : this.globalColors[1].rgb)
       const obj = new EnhancedTHREE.Line2(
         geometry,
         new EnhancedTHREE.LineMaterial({
           linewidth: 10,
-          color: index % 2 === 0 ? this.globalColors[0] : this.globalColors[1],
+          color: index % 2 === 0 ? this.globalColors[0].rgb
+            : this.globalColors[1].rgb,
           dashed: false,
           depthTest: false,
           transparent: true,
@@ -96,13 +97,16 @@ export default class Angles {
     this.group.children.forEach((child, index) => {
       if (child !== undefined && child !== null) {
         if (organColors[index]) {
-          const matColor = new THREE.Color(organColors[index])
+          const matColor = new THREE.Color(organColors[index].rgb)
           child.customColor = matColor
           child.material.color = matColor
+          child.material.opacity = organColors[index].a
         } else {
           child.customColor = null
+          child.material.opacity =
+            this.globalColors[index % 2 ? 1 : 0].a
           child.material.color =
-           new THREE.Color(this.globalColors[index % 2 ? 1 : 0])
+            new THREE.Color(this.globalColors[index % 2 ? 1 : 0].rgb)
         }
       }
     })
@@ -114,11 +118,13 @@ export default class Angles {
     this.group.children.forEach((child, index) => {
       if (!child.customColor) {
         if (index % 2) {
-          const color = new THREE.Color(globalColors[1])
+          const color = new THREE.Color(globalColors[1].rgb)
           child.material.color = color
+          child.material.opacity = globalColors[1].a
         } else {
-          const color = new THREE.Color(globalColors[0])
+          const color = new THREE.Color(globalColors[0].rgb)
           child.material.color = color
+          child.material.opacity = globalColors[0].a
         }
       }
     })
@@ -135,8 +141,8 @@ export default class Angles {
       child.visible = !!ref
 
       const defaultColor = new THREE.Color((i % 2)
-        ? this.globalColors[1]
-        : this.globalColors[0])
+        ? this.globalColors[1].rgb
+        : this.globalColors[0].rgb)
 
       child.material.color = (ref && refIndex >= 0)
         ? child.customColor

--- a/src/Viewer/World/entities/mesh.js
+++ b/src/Viewer/World/entities/mesh.js
@@ -60,13 +60,8 @@ export default class Mesh {
 
   setColor (color) {
     if (color) {
-      this.object.material.color = new THREE.Color(color)
-    }
-  }
-
-  setOpacity (opacity) {
-    if (opacity) {
-      this.object.material.opacity = opacity
+      this.object.material.color = new THREE.Color(color.rgb)
+      this.object.material.opacity = color.a
     }
   }
 }

--- a/src/Viewer/World/entities/pointCloud.js
+++ b/src/Viewer/World/entities/pointCloud.js
@@ -47,10 +47,11 @@ const vertexShader = `
 `
 const fragmentShader = `
   varying vec3 vColor;
+  uniform float opacity;
 
   void main() {
     if ( length( gl_PointCoord - vec2( 0.5, 0.5 ) ) > 0.475 ) discard;
-    gl_FragColor = vec4( vColor, 0.5 );
+    gl_FragColor = vec4( vColor, opacity );
   }
 `
 
@@ -65,6 +66,7 @@ export default class Mesh {
 
     this.material = new THREE.ShaderMaterial({
       uniforms: {
+        opacity: { value: 1 },
         ratio: { type: 'f', value: pixelRatio },
         color: { type: 'c', value: new THREE.Color(0xf8de96) },
         zoom: { type: 'f', value: 1 }
@@ -97,6 +99,10 @@ export default class Mesh {
   }
 
   setColor (color) {
-    if (color) this.material.uniforms.color.value = new THREE.Color(color)
+    if (color && color.rgb && color.a) {
+      this.material.uniforms.color.value = new THREE.Color(color.rgb)
+      this.material.uniforms.opacity.value = color.a
+      console.log(this.material.uniforms.opacity.value)
+    }
   }
 }

--- a/src/Viewer/World/entities/skeleton.js
+++ b/src/Viewer/World/entities/skeleton.js
@@ -65,6 +65,8 @@ export default class Skeleton {
         new EnhancedTHREE.LineMaterial({
           linewidth: 4,
           color: 0x5ca001,
+          transparent: true,
+          opacity: 1,
           dashed: true,
           resolution: { x: window.innerWidth, y: window.innerHeight }
         })
@@ -91,7 +93,8 @@ export default class Skeleton {
 
   setColor (color) {
     this.group.children.forEach((child) => {
-      child.material.color = new THREE.Color(color)
+      child.material.color = new THREE.Color(color.rgb)
+      child.material.opacity = color.a
     })
   }
 }

--- a/src/Viewer/World/index.js
+++ b/src/Viewer/World/index.js
@@ -262,10 +262,9 @@ export default function WorldComponent (props) {
     () => {
       if (world) {
         world.setMeshColor(colors.mesh)
-        world.setMeshOpacity(colors.meshOpacity)
       }
     },
-    [colors.mesh, colors.meshOpacity]
+    [colors.mesh]
   )
 
   useEffect(

--- a/src/Viewer/World/object.js
+++ b/src/Viewer/World/object.js
@@ -75,7 +75,7 @@ export default class World {
 
     this.setControls()
 
-    this.renderer = new THREE.WebGLRenderer({ antialias: true })
+    this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
     this.renderer.setPixelRatio(
       window.devicePixelRatio
         ? window.devicePixelRatio
@@ -378,12 +378,6 @@ export default class World {
   setMeshColor (color) {
     if (this.mesh) {
       this.mesh.setColor(color)
-    }
-  }
-
-  setMeshOpacity (opacity) {
-    if (this.mesh) {
-      this.mesh.setOpacity(opacity)
     }
   }
 

--- a/src/flow/interactions/reducer.js
+++ b/src/flow/interactions/reducer.js
@@ -34,12 +34,11 @@ const initialState = {
   selectedAngle: null,
 
   colors: {
-    mesh: '#96c0a7',
-    meshOpacity: 1,
-    pointCloud: '#f8de96',
-    skeleton: '#5ca001',
+    mesh: { rgb: '#96c0a7', a: 1 },
+    pointCloud: { rgb: '#f8de96', a: 1 },
+    skeleton: { rgb: '#5ca001', a: 1 },
     organs: [],
-    globalOrganColors: ['#3a4d45', '#00a960'],
+    globalOrganColors: [{ rgb: '#3a4d45', a: 0.2 }, { rgb: '#00a960', a: 0.2 }],
     background: '#ecf3f0'
   },
 


### PR DESCRIPTION
Might have to revisit this change later because of color picker
ergonomy.

There is a weird bug with the opacity color picker but I think it comes from the react-color package since there is a somewhat recent issue about it : https://github.com/casesandberg/react-color/issues/720 .

With a bit of luck it might be fixed.

I didn't add opacity to the background because it doesn't really make sense since it's the background and there is nothing behind it.