### PR TITLE
Add `relativeScanFilesURIEnhancer` to ensure correct file paths for

### DIFF
--- a/src/flow/scans/accessors.js
+++ b/src/flow/scans/accessors.js
@@ -43,7 +43,8 @@ import {
   relativeScansPhotoURIEnhancer,
   relativeScansFilesURIEnhancer,
   relativeScanPhotoURIEnhancer,
-  forgeCameraPointsEnhancer
+  forgeCameraPointsEnhancer,
+  relativeScanFilesURIEnhancer
 } from './enhancers'
 
 export function useScan () {
@@ -55,6 +56,7 @@ export function useScan () {
     () => {
       if (scanData) {
         return chain([
+          relativeScanFilesURIEnhancer,
           relativeScanPhotoURIEnhancer,
           forgeCameraPointsEnhancer
         ], scanData)

--- a/src/flow/scans/enhancers.js
+++ b/src/flow/scans/enhancers.js
@@ -74,6 +74,19 @@ export const relativeScansFilesURIEnhancer = (scans) => {
   })
 }
 
+export const relativeScanFilesURIEnhancer = (scan) => {
+  return {
+    ...scan,
+    metadata: {
+      ...scan.metadata,
+      files: {
+        archive: getScanPhotoURI(scan.metadata.files.archive),
+        metadatas: getScanPhotoURI(scan.metadata.files.metadatas)
+      }
+    }
+  }
+}
+
 export const forgeCameraPointsEnhancer = (scan) => {
   const poses = scan.camera.poses
   let index = 0


### PR DESCRIPTION
metadata and archive in singulare scans

This bug wasn't found before because there is no problem when the
visualizer and the database are hosted on the same server.

Close #30 