### PR TITLE
Add `removeEventListener` in `useMouse` hook's cleanup function

### DIFF
--- a/src/rd/tools/hooks/mouse.js
+++ b/src/rd/tools/hooks/mouse.js
@@ -40,7 +40,10 @@ const useMouse = () => {
     }
 
     window.addEventListener('mousemove', handler)
-    return () => window.removeEventListener('resize', handler)
+    return () => {
+      window.removeEventListener('resize', handler)
+      window.removeEventListener('mousemove', handler)
+    }
   }, [1])
 
   return state


### PR DESCRIPTION
Close #33 