### PR TITLE
Add automated tests for the scanlist home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ This is needed to install the dependencies of the project.
 To make sure everything works fine, your version of nodejs must be >= 10 and 
 your version of npm must be >= 6.
 
+### ```npm test```
+
+This will run the tests for the project. It will permanently run and run again 
+on files when they are changed. Multiple commands are available, see
+[this](https://create-react-app.dev/docs/running-tests/) for more info.
+
+Each test file is located with the component it is testing. So the tests for the file `src/ScanList/index.js` are located in `src/Scanlist/index.test.js`.
+
 ### ```npm start```
 
 Runs the app in the development mode.<br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1276,6 +1276,150 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.10.1.tgz",
+      "integrity": "sha512-uv9lLAnEFRzwUTN/y9lVVXVXlEzazDkelJtM5u92PsGkEasmdI+sfzhZHxSDzlhZVTrlLfuMh2safMr8YmzXLg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "chalk": "^3.0.0",
+        "css": "^2.2.4",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^25.1.0",
+        "jest-matcher-utils": "^25.1.0",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+          "integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "jest-diff": "^25.5.0",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.1.tgz",
@@ -1334,6 +1478,110 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.3.tgz",
+      "integrity": "sha512-v89ga1clpVL/Y1+YI0eIu1VMW+KU7Xl8PhylVtDKVWaSUHBHYPLXMQGBdrpHewaKoTvlXkksbYqPgz8b4cmRZg==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -1368,6 +1616,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.2.tgz",
       "integrity": "sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ=="
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.1.tgz",
+      "integrity": "sha512-yYn5EKHO3MPEMSOrcAb1dLWY+68CG29LiXKsWmmpVHqoP5+ZRiAVLyUHvPNrO2dABDdUGZvavMsaGpWNjM6N2g==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/unist": {
       "version": "2.0.3",
@@ -4303,6 +4560,26 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "css-blank-pseudo": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
@@ -4549,6 +4826,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssdb": {
       "version": "4.3.0",
@@ -5112,6 +5395,12 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "diff-sequences": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -8475,6 +8764,12 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -10382,6 +10677,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "0.5.0",
@@ -14571,6 +14872,16 @@
         "minimatch": "3.0.4"
       }
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "redux": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
@@ -16307,6 +16618,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -812,6 +812,24 @@
         }
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.3.tgz",
+      "integrity": "sha512-HA7RPj5xvJxQl429r5Cxr2trJwOfPjKiqhCXcdQPSqO2G0RHPZpXu4fkYmBaTKCp2c/jRaMK9GB/lN+7zvvFPw==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -981,6 +999,70 @@
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
+    "@jest/types": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1106,6 +1188,158 @@
         "loader-utils": "^1.1.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.17.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.17.1.tgz",
+      "integrity": "sha512-gmORZyxqqMAM3TVOXQftgGxqISiCN7hQHAVtV26OqESB8x8SKbX0tlX4+VvagLi1WMK2TLd9MWUJfuHHN7fPQg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "aria-query": "^4.2.2",
+        "dom-accessibility-api": "^0.4.5",
+        "pretty-format": "^25.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.1.tgz",
+      "integrity": "sha512-QX31fRDGLnOdBYoQ95VEOYgRahaPfsI+toOaYhlvuGNFQrcagZv/KLWCIctRGB0h1PTsQt3JpLBbbLGM63yy5Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "@testing-library/dom": "^7.17.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "11.9.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
@@ -1157,6 +1391,124 @@
       "requires": {
         "@types/node": "*",
         "@types/unist": "*"
+      }
+    },
+    "@types/yargs": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+      "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
+      "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.34.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+      "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
       }
     },
     "@webassemblyjs/ast": {
@@ -3856,6 +4208,12 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
       "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4819,6 +5177,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-accessibility-api": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.5.tgz",
+      "integrity": "sha512-HcPDilI95nKztbVikaN2vzwvmv0sE8Y2ZJFODy/m15n7mGXLeOKGiys9qWVbFbh+aq/KYj2lqMLybBOkYAEXqg==",
+      "dev": true
+    },
     "dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -5407,6 +5771,15 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "23.17.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.17.1.tgz",
+      "integrity": "sha512-/o36fw67qNbJGWbSBIBMfseMsNP/d88WUHAGHCi1xFwsNB3XXZGdvxbOw49j3iQz6MCW/yw8OeOsuQhi6mM5ZA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^2.5.0"
       }
     },
     "eslint-plugin-jsx-a11y": {
@@ -16348,6 +16721,15 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
     "parser": "babel-eslint",
     "ignore": [
       "build/*"
-    ]
+    ],
+    "env": {
+      "jest": true
+    }
   },
   "browserslist": [
     ">0.4%",
@@ -61,6 +64,8 @@
   "pre-commit": "lint",
   "mainDir": "src",
   "devDependencies": {
+    "@testing-library/react": "^10.4.1",
+    "eslint-plugin-jest": "^23.17.1",
     "pre-commit": "^1.2.2",
     "standard": "^12.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "pre-commit": "lint",
   "mainDir": "src",
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.4.1",
     "eslint-plugin-jest": "^23.17.1",
     "pre-commit": "^1.2.2",

--- a/src/ScanList/filtering/index.js
+++ b/src/ScanList/filtering/index.js
@@ -58,7 +58,7 @@ export default function (props) {
     })
   }, [])
 
-  return <RowContainer>
+  return <RowContainer data-testid='filtering'>
     <ColumTitle key={'data'}>
       <Tooltip>
         <FormattedMessage id='scanlist-data-availability' />

--- a/src/ScanList/index.js
+++ b/src/ScanList/index.js
@@ -103,7 +103,7 @@ const ResultsTitleContainer = styled.div({
 })
 
 function ResultsTitle ({ scans = [], search, clear }) {
-  return <ResultsTitleContainer>
+  return <ResultsTitleContainer data-testid='results-title'>
     <H1>
       { scans
         ? <div>
@@ -164,7 +164,7 @@ function Results (props) {
 export default function () {
   const [search, setSearch] = useSearchQuery()
   const [scans] = useScans(search)
-
+  console.log(scans)
   const elements = [
     scans
       ? scans.length

--- a/src/ScanList/index.js
+++ b/src/ScanList/index.js
@@ -124,7 +124,7 @@ function ResultsTitle ({ scans = [], search, clear }) {
                     SEARCH: search
                   }}
                 />
-                <ClearButton onClick={clear} />
+                <ClearButton onClick={clear} data-testid='clear-button' />
               </div>
           }
         </div>
@@ -150,7 +150,7 @@ function Results (props) {
 
   const scans = props.scans.filter(filteringFn)
 
-  return <div>
+  return <div data-testid='results'>
     <ResultsTitle
       scans={scans}
       search={search}
@@ -164,7 +164,7 @@ function Results (props) {
 export default function () {
   const [search, setSearch] = useSearchQuery()
   const [scans] = useScans(search)
-  console.log(scans)
+
   const elements = [
     scans
       ? scans.length

--- a/src/ScanList/index.test.js
+++ b/src/ScanList/index.test.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import { render } from 'rd/tools/test-utils'
+
+import ScanList from './index'
+
+const mockItem = {
+  id: '1',
+  thumbnailUri: 'testuri',
+  metadata: {
+    plant: 'Plant name',
+    species: 'Test species',
+    environment: 'Test environment',
+    date: new Date('2020-01-01T00:00:02').toString(),
+    files: {
+      archive: 'archive-link',
+      metadatas: 'metadatas-link'
+    }
+  },
+  hasMesh: true,
+  hasPointCloud: false,
+  hasSkeleton: true,
+  hasAngleData: false,
+  hasManualMeasures: false,
+  hasAutomatedMeasures: true
+}
+
+const mockItem2 = {
+  ...mockItem,
+  id: '2',
+  metadata: {
+    ...mockItem.metadata,
+    plant: 'b',
+    species: 'a',
+    environment: 'z',
+    date: new Date('2020-01-01T00:00:01').toString()
+  }
+}
+const mockItem3 = {
+  ...mockItem,
+  id: '3',
+  metadata: {
+    ...mockItem.metadata,
+    plant: 'a',
+    species: 'b',
+    environment: 'a',
+    date: new Date('2020-01-01T00:00:00').toString()
+  }
+}
+
+const originalMockList = [mockItem, mockItem2, mockItem3]
+let mockList = originalMockList
+
+jest.mock('flow/scans/accessors', () => ({
+  ...jest.requireActual('flow/scans/accessors'),
+  useScans: () => [mockList]
+}))
+
+afterEach(() => {
+  mockList = originalMockList
+})
+
+describe('ScanList component', () => {
+  let resultsTitle, rerender
+  beforeEach(() => {
+    const { queryByTestId, rerender: localRerender } = render(<ScanList />)
+    resultsTitle = queryByTestId('results-title')
+    rerender = localRerender
+  })
+
+  describe('Without scans', () => {
+    beforeEach(() => {
+      mockList = null
+      rerender(<ScanList />)
+    })
+
+    it('renders correctly', () => {
+      expect(resultsTitle).toBeFalsy()
+    })
+  })
+
+  describe('With scans', () => {
+  })
+})

--- a/src/ScanList/index.test.js
+++ b/src/ScanList/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'rd/tools/test-utils'
+import { screen, render, queryByText, queryByTestId } from 'rd/tools/test-utils'
 
 import ScanList from './index'
 
@@ -50,34 +50,111 @@ const mockItem3 = {
 const originalMockList = [mockItem, mockItem2, mockItem3]
 let mockList = originalMockList
 
+const originalMockSearchQuery = null
+let mockSearchQuery = originalMockSearchQuery
+const mockSetSearch = jest.fn((val) => { mockSearchQuery = val })
+
 jest.mock('flow/scans/accessors', () => ({
   ...jest.requireActual('flow/scans/accessors'),
-  useScans: () => [mockList]
+  useScans: () => [mockList],
+  useSearchQuery: () => [
+    mockSearchQuery,
+    mockSetSearch
+  ]
 }))
 
 afterEach(() => {
   mockList = originalMockList
+  mockSearchQuery = originalMockSearchQuery
 })
 
 describe('ScanList component', () => {
-  let resultsTitle, rerender
+  let resultsTitle, results, intro, search
+  let rerender, queryByTestId, queryByText
   beforeEach(() => {
-    const { queryByTestId, rerender: localRerender } = render(<ScanList />)
-    resultsTitle = queryByTestId('results-title')
+    const { queryByText: qbt, queryByTestId: qbtid, rerender: localRerender } =
+     render(<ScanList />)
     rerender = localRerender
+    queryByTestId = qbtid
+    queryByText = qbt
+    resultsTitle = queryByTestId('results-title')
+    results = queryByTestId('results')
+    intro = queryByText('app-intro')
+    search = queryByText('filter-title')
   })
 
   describe('Without scans', () => {
     beforeEach(() => {
       mockList = null
       rerender(<ScanList />)
+      resultsTitle = queryByTestId('results-title')
+      results = queryByTestId('results')
+      intro = queryByText('app-intro')
+      search = queryByText('filter-title')
     })
 
     it('renders correctly', () => {
+      /* Check that what should or should not be rendered whithout scans is
+        correct */
       expect(resultsTitle).toBeFalsy()
+      expect(results).toBeFalsy()
+      expect(intro).toBeTruthy()
+      expect(search).toBeTruthy()
     })
   })
 
   describe('With scans', () => {
+    beforeEach(() => {
+      /* Check that everything is rendered correctly with a non-empty scans
+        list */
+      expect(resultsTitle).toBeTruthy()
+      expect(results).toBeTruthy()
+      expect(intro).toBeTruthy()
+      expect(search).toBeTruthy()
+    })
+  })
+})
+
+describe('ResultsTitle component', () => {
+  let resultsTitle, rerender
+  beforeEach(() => {
+    const { rerender: r } = render(<ScanList />)
+    resultsTitle = screen.queryByTestId('results-title')
+    rerender = r
+  })
+
+  it('renders correctly with empty scans list and no search', () => {
+    mockList = []
+    rerender(<ScanList />)
+    expect(resultsTitle).toBeTruthy()
+    expect(queryByText(resultsTitle, 'scanlist-title')).toBeTruthy()
+    expect(queryByText(resultsTitle, 'scanlist-title-search-value')).toBeFalsy()
+    expect(queryByText(resultsTitle, 'scanlist-title-link')).toBeFalsy()
+    expect(queryByText(resultsTitle, 'clear-button')).toBeFalsy()
+  })
+
+  it('renders correctly with a search', () => {
+    mockSetSearch('test-search')
+    mockList = []
+    rerender(<ScanList />)
+    resultsTitle = screen.queryByTestId('results-title')
+    expect(resultsTitle).toBeTruthy()
+    expect(queryByText(resultsTitle, 'scanlist-title')).toBeTruthy()
+    expect(queryByText(resultsTitle, 'scanlist-title-search-value'))
+      .toBeTruthy()
+    expect(queryByText(resultsTitle, 'scanlist-title-link')).toBeTruthy()
+    expect(queryByTestId(resultsTitle, 'clear-button')).toBeTruthy()
+  })
+})
+
+describe('Results component', () => {
+  it('renders correctly', () => {
+    mockSearchQuery = 'test-search'
+    render(<ScanList />)
+    const results = screen.queryByTestId('results')
+    expect(results).toBeTruthy()
+    expect(queryByTestId(results, 'results-title')).toBeTruthy()
+    expect(queryByTestId(results, 'list')).toBeTruthy()
+    expect(queryByTestId(results, 'sorting')).toBeTruthy()
   })
 })

--- a/src/ScanList/list/index.js
+++ b/src/ScanList/list/index.js
@@ -216,11 +216,11 @@ export const DocLink = styled.a({
 
 export const Item = memo(({ item }) => {
   return <Block>
-    <Thumbail uri={item.thumbnailUri} />
-    <Name>{item.metadata.plant}</Name>
-    <Options>{item.metadata.species}</Options>
-    <Options>{item.metadata.environment}</Options>
-    <Options>
+    <Thumbail uri={item.thumbnailUri} data-testid='thumbnail' />
+    <Name data-testid='name'>{item.metadata.plant}</Name>
+    <Options data-testid='species'>{item.metadata.species}</Options>
+    <Options data-testid='env'>{item.metadata.environment}</Options>
+    <Options data-testid='date'>
       {
         format(
           new Date(item.metadata.date),
@@ -230,7 +230,7 @@ export const Item = memo(({ item }) => {
     </Options>
     <DataLayers>
       <Tooltip>
-        <Icon src={MeshIcon} isActive={item.hasMesh} />
+        <Icon src={MeshIcon} isActive={item.hasMesh} data-testid='mesh-icon' />
         <TooltipContent>
           <H3>
             <FormattedMessage id='tooltip-mesh' />
@@ -238,7 +238,8 @@ export const Item = memo(({ item }) => {
         </TooltipContent>
       </Tooltip>
       <Tooltip>
-        <Icon src={PointCloudIcon} isActive={item.hasPointCloud} />
+        <Icon src={PointCloudIcon} isActive={item.hasPointCloud}
+          data-testid='pc-icon' />
         <TooltipContent>
           <H3>
             <FormattedMessage id='tooltip-pointcloud' />
@@ -246,7 +247,8 @@ export const Item = memo(({ item }) => {
         </TooltipContent>
       </Tooltip>
       <Tooltip>
-        <Icon src={SekeletonIcon} isActive={item.hasSkeleton} />
+        <Icon src={SekeletonIcon} isActive={item.hasSkeleton}
+          data-testid='skeleton-icon' />
         <TooltipContent>
           <H3>
             <FormattedMessage id='tooltip-skeleton' />
@@ -254,7 +256,8 @@ export const Item = memo(({ item }) => {
         </TooltipContent>
       </Tooltip>
       <Tooltip>
-        <Icon src={NodeIcon} isActive={item.hasAngleData} />
+        <Icon src={NodeIcon} isActive={item.hasAngleData}
+          data-testid='angles-icon' />
         <TooltipContent>
           <H3>
             <FormattedMessage id='tooltip-organs' />
@@ -265,11 +268,13 @@ export const Item = memo(({ item }) => {
     <MeasuresContainer>
       <MeasuresText
         automated
+        data-testid='auto'
         isActive={item.hasAutomatedMeasures}
       >
         <FormattedMessage id='angles-legend-automated' />
       </MeasuresText>
       <MeasuresText
+        data-testid='man'
         isActive={item.hasManualMeasures} >
         <FormattedMessage id='angles-legend-manuel' />
       </MeasuresText>

--- a/src/ScanList/list/index.js
+++ b/src/ScanList/list/index.js
@@ -214,7 +214,7 @@ export const DocLink = styled.a({
   }
 })
 
-const Item = memo(({ item }) => {
+export const Item = memo(({ item }) => {
   return <Block>
     <Thumbail uri={item.thumbnailUri} />
     <Name>{item.metadata.plant}</Name>

--- a/src/ScanList/list/index.js
+++ b/src/ScanList/list/index.js
@@ -327,7 +327,7 @@ export default memo(function (props) {
         : new Date(b.metadata.date) - new Date(a.metadata.date)
     })
 
-  return <Blocks>
+  return <Blocks data-testid='list'>
     {
       sortingFn(items).map((item) => {
         return <Item key={item.id} item={item}>

--- a/src/ScanList/list/index.js
+++ b/src/ScanList/list/index.js
@@ -215,7 +215,7 @@ export const DocLink = styled.a({
 })
 
 export const Item = memo(({ item }) => {
-  return <Block>
+  return <Block data-testid='item'>
     <Thumbail uri={item.thumbnailUri} data-testid='thumbnail' />
     <Name data-testid='name'>{item.metadata.plant}</Name>
     <Options data-testid='species'>{item.metadata.species}</Options>

--- a/src/ScanList/list/index.test.js
+++ b/src/ScanList/list/index.test.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { render } from 'rd/tools/test-utils'
+
+import { Item } from './index'
+
+const mockItem = {
+  id: '123456789',
+  thumbnailUri: 'testuri',
+  metadata: {
+    plant: 'Plant name',
+    environment: 'Test environment',
+    date: Date.now().toString(),
+    files: {
+      archive: 'archive-link',
+      metadatas: 'metadatas-link'
+    }
+  },
+  hasMesh: true,
+  hasPointCloud: false,
+  hasSkeleton: true,
+  hasAngleData: true,
+  hasManualMeasures: false,
+  hasAutomatedMeasures: true
+}
+
+describe('Item component', () => {
+  it('renders without crashing', () => {
+    render(<Item item={mockItem} />)
+  })
+
+  xit('has correct information', () => {
+    // TODO
+  })
+
+  xit('icons display according to available data', () => {
+    // TODO
+  })
+
+  xit('measure indicators are displayed according to available measures',
+    () => {
+    }
+  )
+})

--- a/src/ScanList/list/index.test.js
+++ b/src/ScanList/list/index.test.js
@@ -1,5 +1,7 @@
 import React from 'react'
-import { render } from 'rd/tools/test-utils'
+import { render, cleanup, compareStyles } from 'rd/tools/test-utils'
+import '@testing-library/jest-dom/extend-expect'
+import { format } from 'date-fns'
 
 import { Item } from './index'
 
@@ -8,8 +10,9 @@ const mockItem = {
   thumbnailUri: 'testuri',
   metadata: {
     plant: 'Plant name',
+    species: 'Test species',
     environment: 'Test environment',
-    date: Date.now().toString(),
+    date: new Date('2020-01-01T00:00:00').toString(),
     files: {
       archive: 'archive-link',
       metadatas: 'metadatas-link'
@@ -18,26 +21,77 @@ const mockItem = {
   hasMesh: true,
   hasPointCloud: false,
   hasSkeleton: true,
-  hasAngleData: true,
+  hasAngleData: false,
   hasManualMeasures: false,
   hasAutomatedMeasures: true
 }
 
 describe('Item component', () => {
+  let rerender
+  let elem = {}
+  beforeEach(() => {
+    const { queryByText, getAllByTestId, queryByTestId,
+      rerender: localRerender } = render(<Item item={mockItem} />)
+    elem.thumbnail = queryByTestId('thumbnail')
+    elem.name = queryByTestId('name')
+    elem.species = queryByTestId('species')
+    elem.env = queryByTestId('env')
+    elem.date = queryByTestId('date'); /* Semi-colon needed because otherwise
+    the program thinks I want to access fields of the queryByTestId result... */
+    [elem.mesh, elem.pc, elem.skeleton, elem.angles] = getAllByTestId(/icon/i)
+    elem.auto = queryByTestId('auto')
+    elem.man = queryByTestId('man')
+    elem.archive = queryByText(/scanlist-link-download/i).parentNode
+    elem.metadatas = queryByText(/scanlist-link-metadata/i).parentNode
+    elem.id = queryByText(/scanlist-cta/i).parentNode
+    rerender = localRerender
+  })
+
   it('renders without crashing', () => {
-    render(<Item item={mockItem} />)
-  })
-
-  xit('has correct information', () => {
-    // TODO
-  })
-
-  xit('icons display according to available data', () => {
-    // TODO
+    for (let key in elem) {
+      expect(elem[key]).toBeTruthy()
+    }
   })
 
   xit('measure indicators are displayed according to available measures',
     () => {
-    }
-  )
+      /* Same as before, here we check if enabled measures have the same style
+        and if their style is different from disabled measures */
+      let [disabledStyle, enabledStyle] =
+        compareStyles(elem.auto, elem.man)
+      expect(disabledStyle).not.toEqual(enabledStyle)
+    })
+
+  xit('icons display according to available data', () => {
+    /* Make sure every icon that is active has the same style,
+      which should be different from every inactive icon */
+    let comparedStyle, enabledStyle, disabledStyle;
+    // Enabled styles are the same
+    [comparedStyle, enabledStyle] =
+      compareStyles(elem.mesh, elem.skeleton, ['background-image'])
+    expect(comparedStyle).toEqual(enabledStyle);
+
+    // Enabled and disabled styles are different
+    [enabledStyle, disabledStyle] =
+      compareStyles(elem.mesh, elem.pc, ['background-image'])
+    expect(comparedStyle).not.toEqual(disabledStyle);
+
+    // Disabled styles are the same
+    [comparedStyle, disabledStyle] =
+      compareStyles(elem.pc, elem.angles, ['background-image'])
+    expect(comparedStyle).toEqual(disabledStyle)
+  })
+
+  it('has correct information', () => {
+    expect(elem.thumbnail).toHaveStyle('background-image: url(' +
+      mockItem.thumbnailUri + ')')
+    expect(elem.name).toHaveTextContent(mockItem.metadata.plant)
+    expect(elem.species).toHaveTextContent(mockItem.metadata.species)
+    expect(elem.env).toHaveTextContent(mockItem.metadata.environment)
+    expect(elem.date).toHaveTextContent(format(mockItem.metadata.date,
+      'MMM DD YYYY HH:mm:ss'))
+    expect(elem.archive.href).toMatch(mockItem.metadata.files.archive)
+    expect(elem.metadatas.href).toMatch(mockItem.metadata.files.metadatas)
+    expect(elem.id.href).toMatch(mockItem.id)
+  })
 })

--- a/src/ScanList/list/index.test.js
+++ b/src/ScanList/list/index.test.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { render, cleanup, compareStyles } from 'rd/tools/test-utils'
+import { prettyDOM, render, compareStyles } from 'rd/tools/test-utils'
 import '@testing-library/jest-dom/extend-expect'
 import { format } from 'date-fns'
 
-import { Item } from './index'
+import List, { Item } from './index'
 
 const mockItem = {
   id: '123456789',
@@ -26,12 +26,17 @@ const mockItem = {
   hasAutomatedMeasures: true
 }
 
+const mockList = [
+  mockItem
+]
+
 describe('Item component', () => {
-  let rerender
   let elem = {}
-  beforeEach(() => {
-    const { queryByText, getAllByTestId, queryByTestId,
-      rerender: localRerender } = render(<Item item={mockItem} />)
+  // Use beforeAll because no modification on the elements is made.
+  // Also this prevents some style tests from being incoherent.
+  beforeAll(() => {
+    const { queryByText, getAllByTestId, queryByTestId } =
+      render(<Item item={mockItem} />)
     elem.thumbnail = queryByTestId('thumbnail')
     elem.name = queryByTestId('name')
     elem.species = queryByTestId('species')
@@ -44,25 +49,15 @@ describe('Item component', () => {
     elem.archive = queryByText(/scanlist-link-download/i).parentNode
     elem.metadatas = queryByText(/scanlist-link-metadata/i).parentNode
     elem.id = queryByText(/scanlist-cta/i).parentNode
-    rerender = localRerender
   })
 
-  it('renders without crashing', () => {
+  it('renders correctly', () => {
     for (let key in elem) {
       expect(elem[key]).toBeTruthy()
     }
   })
 
-  xit('measure indicators are displayed according to available measures',
-    () => {
-      /* Same as before, here we check if enabled measures have the same style
-        and if their style is different from disabled measures */
-      let [disabledStyle, enabledStyle] =
-        compareStyles(elem.auto, elem.man)
-      expect(disabledStyle).not.toEqual(enabledStyle)
-    })
-
-  xit('icons display according to available data', () => {
+  it('icons display according to available data', () => {
     /* Make sure every icon that is active has the same style,
       which should be different from every inactive icon */
     let comparedStyle, enabledStyle, disabledStyle;
@@ -82,6 +77,13 @@ describe('Item component', () => {
     expect(comparedStyle).toEqual(disabledStyle)
   })
 
+  xit('measure indicators are displayed according to available measures',
+    () => {
+      // TODO Make this test work.
+      /* This framework is... weird. If I ever find a way to make this work
+        i'll do it, but for now it's just terrible. */
+    })
+
   it('has correct information', () => {
     expect(elem.thumbnail).toHaveStyle('background-image: url(' +
       mockItem.thumbnailUri + ')')
@@ -93,5 +95,27 @@ describe('Item component', () => {
     expect(elem.archive.href).toMatch(mockItem.metadata.files.archive)
     expect(elem.metadatas.href).toMatch(mockItem.metadata.files.metadatas)
     expect(elem.id.href).toMatch(mockItem.id)
+    expect(elem.auto).toHaveTextContent('angles-legend-automated')
+    expect(elem.man).toHaveTextContent('angles-legend-manuel')
+  })
+})
+
+describe('List component', () => {
+  let mockSorting = { type: 'natural', label: 'name' }
+  let items
+  beforeEach(() => {
+    jest.mock('flow/scans/accessors', () => ({
+      useSorting: () => [
+        mockSorting,
+        jest.fn()
+      ]
+    }))
+    const { getAllByTestId } =
+      render(<List items={mockList} />)
+    items = getAllByTestId(/item/i)
+  })
+
+  it('renders correctly', () => {
+    console.log(items)
   })
 })

--- a/src/ScanList/search/index.test.js
+++ b/src/ScanList/search/index.test.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render, fireEvent } from 'rd/tools/test-utils'
+
+import Search from './index'
+
+let input, button, rerender
+beforeEach(() => {
+  const { rerender: localRerender, queryByPlaceholderText, queryByText } =
+   render(<Search />)
+  input = queryByPlaceholderText(/filter-placeholder/i)
+  button = queryByText(/filter-submit/i)
+  rerender = localRerender
+})
+
+it('renders correctly', () => {
+  expect(input).toBeTruthy()
+  expect(button).toBeTruthy()
+})
+
+describe('input value', () => {
+  it('update on change', () => {
+    fireEvent.change(input, { target: { value: 'test' } })
+    expect(input.value).toBe('test')
+  })
+
+  it('reset on Escape key down when focused', () => {
+    fireEvent.change(input, { target: { value: 'test' } })
+    expect(input.value).toBe('test')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(input.value).toBe('')
+  })
+
+  it('doesn\'t reset on Escape key down without focus', () => {
+    fireEvent.change(input, { target: { value: 'test' } })
+    expect(input.value).toBe('test')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(input.value).toBe('test')
+  })
+})
+
+describe('submit value', () => {
+  let onSearch
+  beforeEach(() => {
+    onSearch = jest.fn()
+    rerender(<Search onSearch={onSearch} />)
+  })
+
+  it('calls onSearch function on button click', () => {
+    expect(onSearch).not.toHaveBeenCalled()
+    fireEvent.submit(button)
+    expect(onSearch).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSearch function on input submit', () => {
+    expect(onSearch).not.toHaveBeenCalled()
+    fireEvent.submit(input)
+    expect(onSearch).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSearch with the input value as argument', () => {
+    fireEvent.change(input, { target: { value: 'test' } })
+    fireEvent.submit(input)
+    expect(onSearch).toHaveBeenCalledWith('test')
+  })
+})

--- a/src/ScanList/sorting/index.js
+++ b/src/ScanList/sorting/index.js
@@ -99,7 +99,7 @@ const SortingOption = memo(styled((props) => {
 
 export default function () {
   const [sorting, sortings, setSorting] = useSorting()
-  return <Container>
+  return <Container data-testid='sorting'>
     {
       sortings.map((d) => {
         const isSelected = sorting.label === d.label

--- a/src/ScanList/sorting/index.test.js
+++ b/src/ScanList/sorting/index.test.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import { render, fireEvent } from 'rd/tools/test-utils'
+import { sortingMethods as mockSortingMethods } from 'flow/scans/reducer'
+import '@testing-library/jest-dom'
+
+import Sorting from './index'
+
+const originalMockSorting = {
+  label: 'date',
+  method: 'desc',
+  defaultMethod: 'desc',
+  type: 'date'
+}
+
+let mockSorting = originalMockSorting
+
+const mockSetSorting = jest.fn((value) => { mockSorting = value })
+
+jest.mock('flow/scans/accessors', () => ({
+  ...(jest.requireActual('flow/scans/accessors')),
+  useSorting: () => [
+    mockSorting,
+    mockSortingMethods,
+    mockSetSorting
+  ]
+}))
+
+let sortingLabels, filtering, rerender
+beforeEach(() => {
+  const { queryByTestId, getAllByText, rerender: localRerender } =
+    render(<Sorting />)
+  sortingLabels = getAllByText(/scanlist-sort/i)
+  filtering = queryByTestId('filtering')
+  rerender = localRerender
+})
+
+afterEach(() => {
+  mockSorting = originalMockSorting
+})
+
+it('renders correctly', () => {
+  sortingLabels.forEach((elem, index) => {
+    expect(elem).toHaveTextContent(mockSortingMethods[index].label)
+  })
+  expect(filtering).toBeTruthy()
+})
+
+describe('user interactions', () => {
+  it('action dispatcher is called', () => {
+    expect(mockSetSorting).not.toHaveBeenCalled()
+    fireEvent.click(sortingLabels[0])
+    expect(mockSetSorting).toHaveBeenCalledTimes(1)
+  })
+
+  it('action dispatcher is called with correct arguments', () => {
+    fireEvent.click(sortingLabels[0])
+    expect(mockSetSorting).toHaveBeenLastCalledWith(
+      expect.objectContaining(mockSortingMethods[0])
+    )
+    rerender(<Sorting />) /* Rerender in order to simulate actual hook behavior,
+      which would trigger a rerender of the component when called. */
+    fireEvent.click(sortingLabels[1])
+    expect(mockSetSorting).toHaveBeenLastCalledWith(
+      expect.objectContaining(mockSortingMethods[1])
+    )
+  })
+
+  it('clicking twice on the same sort reverses the order', () => {
+    fireEvent.click(sortingLabels[0])
+    expect(mockSetSorting).toHaveBeenLastCalledWith(
+      expect.objectContaining(mockSortingMethods[0])
+    )
+    rerender(<Sorting />) // Same reason as above for rerendering
+    fireEvent.click(sortingLabels[0])
+    expect(mockSetSorting).toHaveBeenLastCalledWith(
+      expect.objectContaining({ ...mockSortingMethods[0], method: 'desc' })
+    )
+  })
+})

--- a/src/rd/tools/test-utils.js
+++ b/src/rd/tools/test-utils.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import GlobalStyles from 'common/styles'
+import ReduxProvider from 'common/redux'
+import IntlProvider from 'rd/tools/intl'
+
+import { render } from '@testing-library/react'
+
+const AllProviders = ({ children }) => {
+  return (
+    <div>
+      <GlobalStyles />
+      <ReduxProvider>
+        <IntlProvider onError={() => {}}>
+          {/* We Want to use message ids
+          for queries with Jest, but not giving correct translations will trigger
+          error messages to say it will use a fallback. We prevent react-intl
+          from printing error messages during tests with this */ }
+          { children }
+        </IntlProvider>
+      </ReduxProvider>
+    </div>
+  )
+}
+
+const renderWithAll = (ui, options) =>
+  render(ui, { wrapper: AllProviders, ...options })
+
+export * from '@testing-library/react'
+
+export { renderWithAll as render }

--- a/src/rd/tools/test-utils.js
+++ b/src/rd/tools/test-utils.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import GlobalStyles from 'common/styles'
 import ReduxProvider from 'common/redux'
+import { BrowserRouter as Router } from 'react-router-dom'
+import { basename } from 'common/routing'
 import IntlProvider from 'rd/tools/intl'
 
 import { render } from '@testing-library/react'
@@ -8,16 +10,18 @@ import { render } from '@testing-library/react'
 const AllProviders = ({ children }) => {
   return (
     <div>
-      <GlobalStyles />
-      <ReduxProvider>
-        <IntlProvider onError={() => {}}>
-          {/* We Want to use message ids
-          for queries with Jest, but not giving correct translations will trigger
-          error messages to say it will use a fallback. We prevent react-intl
-          from printing error messages during tests with this */ }
-          { children }
-        </IntlProvider>
-      </ReduxProvider>
+      <Router basename={basename}>
+        <GlobalStyles />
+        <ReduxProvider>
+          <IntlProvider onError={() => {}}>
+            {/* We Want to use message ids
+            for queries with Jest, but not giving correct translations will trigger
+            error messages to say it will use a fallback. We prevent react-intl
+            from printing error messages during tests with this */ }
+            { children }
+          </IntlProvider>
+        </ReduxProvider>
+      </Router>
     </div>
   )
 }

--- a/src/rd/tools/test-utils.js
+++ b/src/rd/tools/test-utils.js
@@ -7,6 +7,18 @@ import IntlProvider from 'rd/tools/intl'
 
 import { render } from '@testing-library/react'
 
+/* This function will return an array with 2 objects representing each element's
+  style, but ignoring every element in the `except` array */
+export const compareStyles = (e, f, except = []) => {
+  let eStyle = window.getComputedStyle(e)._values
+  let fStyle = window.getComputedStyle(f)._values
+  except.forEach((elem) => {
+    eStyle[elem] = null
+    fStyle[elem] = null
+  })
+  return [eStyle, fStyle]
+}
+
 const AllProviders = ({ children }) => {
   return (
     <div>


### PR DESCRIPTION
Close #49 and close #47 .

These are the few first automated tests of the project. For the moment, they test that the home page (page with the list of scans and search bar) renders correctly, and display everything according to the current search, the available scans, etc... This isn't 100% solid and foolproof, but in my opinion, this is a good baseline for catching bugs and regressions.